### PR TITLE
Add Github Actions pipeline to Project

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,34 @@
+name: Android CI Pipepline
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+  # Scheduled for 3am UTC every day except Sunday
+  schedule:
+    - cron: '0 3 * * 1-5' # 2:00 AM UTC
+    
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Nightly Build
+    if: github.event_name == 'schedule' && github.ref == 'refs/heads/main'  
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the Repository
+    - uses: actions/checkout@v4
+    
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+      
+    - name: Build with Gradle
+      run: ./gradlew build


### PR DESCRIPTION
Added Github actions CI pipeline to build gradle project on schedule as a nightly build for 3am UTC.

-> Pipeline runs a Nightly build
-> 3am UTC, Mon -Fri (scheduled)
-> Also leverages a manual push or Pull request to main trigger for the workflow to run
-> Schedule only runs on main